### PR TITLE
UX: background-attachment fix for iOS

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -6,23 +6,28 @@
   box-shadow: 0 1px $value rgba(black, 0.18);
 }
 
-body {
+.background-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
   background-color: $primary-very-low;
   @if $no-background-image == "false" {
     @if $background-image != "default" {
       // Thanks @tmoko!
       background-image: url($background-image);
     } @else {
+      // Default background pattern from Toptal Subtle Patterns
+      // ♡ https://www.toptal.com/designers/subtlepatterns/japanese-sayagata/
       background-image: url($default-background);
     }
-    // Default background pattern from Toptal Subtle Patterns
-    // ♡ https://www.toptal.com/designers/subtlepatterns/japanese-sayagata/
-    background-attachment: fixed;
     @if $tile-background == "true" {
       background-size: auto;
     } @else {
       background-size: cover;
       background-repeat: no-repeat;
+      background-position: center center;
     }
   }
 }

--- a/common/header.html
+++ b/common/header.html
@@ -1,0 +1,1 @@
+<div class="background-container"></div>


### PR DESCRIPTION
iOS devices ignore `background-attachment: fixed` due to their concerns about its performance costs. This PR moves the theme background to a separate element that's set to `position: fixed` as a means to work around that limitation. This PR affects all devices but introduces no visual changes whatsoever. Everything should look exactly the same. 

It only allows the same effect to work on iOS devices with the added benefit of improved scroll performance for other types of devices.