### PR TITLE
UX: fix social login button color, sidebar headings, transparent buttons

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -92,10 +92,6 @@ pre {
   border-color: transparent;
 }
 
-.btn.btn-social {
-  color: var(--secondary);
-}
-
 .btn.btn-danger:not(.btn-flat) {
   background: var(--danger);
   color: var(--secondary);

--- a/common/common.scss
+++ b/common/common.scss
@@ -68,7 +68,7 @@ pre {
   width: 100%;
 }
 
-.btn:not(.btn-flat):not(.btn-social),
+.btn:not(.btn-flat):not(.btn-social):not(.btn-transparent),
 .select-kit.dropdown-select-box .dropdown-select-box-header {
   border: 1px solid var(--gf-primary-low-or-low-mid, $primary-low);
   color: var(--primary-high, $primary-high);

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -303,7 +303,7 @@ body.has-sidebar-page {
 }
 
 .sidebar-section-header {
-  border: none;
+  border: none !important; // button rule upstream is very specific
 }
 
 // chat


### PR DESCRIPTION
This fixes social logins so the text is visible — this CSS was from back when the buttons had background colors

Before: 
 
![image](https://github.com/discourse/graceful/assets/1681963/442e1367-551a-41a7-a8a3-97fe8a3b776d)

After:

![image](https://github.com/discourse/graceful/assets/1681963/dff12107-06d7-44a2-8528-79761d31bc2b)

