### PR TITLE
UX: fix powered by discourse location, delete button color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -92,7 +92,7 @@ pre {
   border-color: transparent;
 }
 
-.btn.btn-danger:not(.btn-flat) {
+.btn.btn-danger:not(.btn-flat):not(.btn-transparent) {
   background: var(--danger);
   color: var(--secondary);
   &:hover {
@@ -427,4 +427,11 @@ body.has-full-page-chat {
 
 .chat-channel {
   height: calc(100vh - (var(--header-offset) + 8em));
+}
+
+.powered-by-discourse {
+  margin-top: 1em;
+  @media screen and (min-width: 1100px) {
+    margin-left: 4em;
+  }
 }


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/graceful/assets/1681963/a2be529b-037a-4906-bf69-ccd0cafe9cca)

![image](https://github.com/discourse/graceful/assets/1681963/2df4ab7c-ba1c-47c3-82d8-f5c35d763e94)



After:

![image](https://github.com/discourse/graceful/assets/1681963/3be1611f-79bc-43a9-a02b-027b4cfd383d)


![image](https://github.com/discourse/graceful/assets/1681963/5d4d347c-b660-4c93-9303-efcbd1b77889)
