### PR TITLE
FIX: Prevent bug with pinch zooming in Safari iOS

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -14,7 +14,6 @@
   left: 0;
   height: 100vh;
   width: 100vw;
-  z-index: -1;
   background-color: var(
     --gf-primary-very-low-or-primary-low,
     $primary-very-low
@@ -36,6 +35,13 @@
       background-position: center center;
     }
   }
+}
+
+#main {
+  // need to show this above the background container
+  // can't use z-index: -1 because of a bug with pinch zoom
+  // in Safari iOS
+  z-index: 1;
 }
 
 .topic-list-body {


### PR DESCRIPTION
Using `z-index: -1` and `position: fixed` in the same element makes Safari crash when pinch zooming the page. It's an upstream bug, but we can avoid this combination here.