### PR TITLE
UX: full screen chat height, dark palette adjustments

### DIFF
--- a/about.json
+++ b/about.json
@@ -21,10 +21,10 @@
     },
     "Graceful Dark": {
       "primary": "c4cfc5",
-      "secondary": "445446",
+      "secondary": "1d261e",
       "tertiary": "88af8e",
       "quaternary": "88af8e",
-      "header_background": "212821",
+      "header_background": "1d261e",
       "header_primary": "ffffff",
       "highlight": "7e9280",
       "danger": "f8745c",

--- a/common/common.scss
+++ b/common/common.scss
@@ -432,7 +432,7 @@ body.has-full-page-chat {
 }
 
 .chat-channel {
-  height: calc(100vh - (var(--header-offset) + 8em));
+  height: calc(100vh - (var(--header-offset) + 6.75em));
 }
 
 .powered-by-discourse {


### PR DESCRIPTION
Before (chat too short: 
![image](https://github.com/user-attachments/assets/bd342546-2b73-4443-837f-4676299e842d)


After:
![image](https://github.com/user-attachments/assets/c885ec20-163b-44a4-b9e6-779d0e4e3d83)


Before (dark too light):
![image](https://github.com/user-attachments/assets/6357a4df-3976-44cd-a872-77d50126a2b3)


After:
![image](https://github.com/user-attachments/assets/4b707533-5ad1-42fb-b7b7-c90a1a904a72)
