### PR TITLE
UX: simplify button styling

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,6 @@
 @use "sass:color";
 
 // Big thanks to jsthon for the initial work on this https://meta.discourse.org/u/jsthon/
-:root {
-  --d-hover: var(--tertiary-low);
-}
 
 @mixin box-shadow($value: 8px) {
   box-shadow: 0 1px $value rgb(black, 0.18);
@@ -81,6 +78,8 @@ pre {
 }
 
 :root {
+  --d-hover: var(--tertiary-low);
+
   // .btn-default
   --d-button-default-text-color: var(--primary);
   --d-button-default-text-color--hover: var(--tertiary);


### PR DESCRIPTION
This simplifies button styling using the newer core variables, which also fixes some minor issues like this...


before: 
<img width="1182" height="486" alt="image" src="https://github.com/user-attachments/assets/a2ddc764-26e0-437f-8dc5-f1ae5bba76b1" />


after:
<img width="1208" height="494" alt="image" src="https://github.com/user-attachments/assets/554cc0c3-aef0-4950-a0e1-ae3b8cb3c0b6" />
